### PR TITLE
add option to supply jsonSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ const { jvro, SchemaRegistryAvroFetcher } = require('javro');
 javro({
   // The location of your JSON Schema
   jsonSchemaFile: '/path/to/your/jsonSchemaFile.json',
+
+  // A JSON schema object. This object will be used instead of reading from `jsonSchemaFile`.
+  jsonSchema: jsonSchemaObject,
   
   // The 'namespace' used in the generated AVSC - the 'name' will be taken either from the 'title' in the JSON Schema or
   // the file name if 'title' isn't present (in this case that would be 'jsonSchemaFile')

--- a/src/javro.js
+++ b/src/javro.js
@@ -45,7 +45,7 @@ function fetchAvroCompatibility(options, res) {
 }
 
 function resolveReferencesAndTurnIntoAvro(options) {
-  return resolveReferences(options.jsonSchemaFile).then((resolvedJson) => {
+  return resolveReferences(options.jsonSchemaFile, options.jsonSchema).then((resolvedJson) => {
     const newAvsc = new JsonSchemaToAvro(resolvedJson, options.allowMultipleTypes || false)
       .mapObjectToRecord(options.namespace, grabAvroName(options.jsonSchemaFile, resolvedJson));
     return fetchCorrespondingAvro(resolvedJson, options).then((oldAvsc) => {

--- a/src/resolve_references.js
+++ b/src/resolve_references.js
@@ -16,6 +16,6 @@
 
 const $RefParser = require('json-schema-ref-parser');
 
-module.exports = function resolveReferences(jsonSchemaUrl) {
-  return $RefParser.dereference(jsonSchemaUrl);
+module.exports = function resolveReferences(jsonSchemaUrl, jsonSchema) {
+  return $RefParser.dereference(jsonSchemaUrl, jsonSchema);
 };

--- a/test/int/simple/simple.int.test.js
+++ b/test/int/simple/simple.int.test.js
@@ -15,6 +15,7 @@
  */
 
 const path = require('path');
+const fs = require('fs');
 const javroWithValidation = require('../../utils/javro-with-validation');
 
 test('primitive types', () => javroWithValidation(path.resolve(__dirname, './primitives.avsc'), {
@@ -55,6 +56,14 @@ test('arrays', () => javroWithValidation(path.resolve(__dirname, './some_arrays.
 
 test('enum', () => javroWithValidation(path.resolve(__dirname, './some_enum.avsc'), {
   jsonSchemaFile: path.resolve(__dirname, './some_enum.json'),
+  namespace: 'test.jsonschema.to.avro.namespace',
+}).then((res) => {
+  expect(res.actualAvro).toStrictEqual(res.expectedAvro);
+}));
+
+test('with jsonSchema', () => javroWithValidation(path.resolve(__dirname, './some_enum.avsc'), {
+  jsonSchemaFile: path.resolve(__dirname, './some_enum.json'),
+  jsonSchema: fs.readFileSync(path.resolve(__dirname, './some_enum.json')),
   namespace: 'test.jsonschema.to.avro.namespace',
 }).then((res) => {
   expect(res.actualAvro).toStrictEqual(res.expectedAvro);

--- a/test/utils/javro-with-validation.js
+++ b/test/utils/javro-with-validation.js
@@ -22,7 +22,7 @@ const $RefParser = require('json-schema-ref-parser');
 const { javro } = require('../../src/javro');
 
 module.exports = function javroWithValidation(expectedAvroFile, options) {
-  const deReferencedSchema = $RefParser.dereference(options.jsonSchemaFile);
+  const deReferencedSchema = $RefParser.dereference(options.jsonSchemaFile, options.jsonSchema);
   const actualAvro = javro(options);
   const expectedAvro = fs.readFile(expectedAvroFile, { encoding: 'UTF-8' });
 


### PR DESCRIPTION
### :pencil: Description
 I have a usecase where I rather supply a json object from memory instead of a file.

#### Added
* adds the ability to supply a JSON schema object as is supported by https://github.com/APIDevTools/json-schema-ref-parser

#### Changed
* an option supplied to `json-schema-ref-parser`

#### Deleted
* _&lt;detail item of what was removed&gt;_

### :link: Related Issues
* _&lt;refer the issue&gt;_




# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
